### PR TITLE
fix: adds compatibility validation functions after detecting bug in L…

### DIFF
--- a/rony/cli.py
+++ b/rony/cli.py
@@ -2,8 +2,8 @@ import click
 import os
 import re
 import sys
-from os import path
 from .writer import copy_files, write_readme_file
+from .validation import get_operational_system, check_version_python, check_python_compile
 from .__init__ import __version__ as version
 
 LOCAL_PATH = os.getcwd()
@@ -50,61 +50,14 @@ def new(project_name):
     write_readme_file(LOCAL_PATH, project_name)
 
     os.chdir(project_name)
-    new.env_name = f"{project_name}_env"
+    env_name = f"{project_name}_env"
+    os.environ["ENV_NAME"] = env_name
+    check_python_compile()
 
     # Create git repo
     os.system('git init')
     print("A git repository was created. You should add your files and make your first commit.\n")
 
-
-env_name = new.env_name    
-    
-def get_operational_system():
-    """
-    Check which user's operating system    
-    """
-    os = sys.platform
-    if sys.platform == "linux":
-        return "Linux"
-    elif sys.platform == "win32":
-        return "Windows"
-    elif sys.platform == "darwin":
-        return "MacOS"
-    elif sys.platform == "freebsd8":
-        return "FreeBSD"
-
-
-def check_version_python():
-    """
-    Checks whether the version of python installed on the system is compatible
-    """
-    if sys.version_info >= (3,6):
-        return True
-    else:
-        return False
-
-def check_python_compile():
-    """
-    Checks python3 path location 
-    """
-    message_env = f"Creating virtual environment {env_name}"
-    if get_operational_system() == "Linux" and check_version_python() == True:
-        if path.exists("/usr/bin/python3") == True:
-            print(message_env)
-            os.system(f"python3 -m venv {env_name}")
-        else:
-            print(message_env)
-            os.system(f"python -m venv {env_name}")
-    elif get_operational_system() == "Windows" and check_version_python() == True:
-        print(message_env)
-        os.system(f"python -m venv {env_name}")
-    elif get_operational_system() == "MacOS" and check_version_python() == True:
-        print(message_env)
-        os.system(f"python -m venv {env_name}")
-    elif check_version_python == False:
-        print('The python version is not supported. Rony is compatible with the version of >= Python 3.6')
-
-check_python_compile()
 
 @click.argument('image_name')
 @cli.command()

--- a/rony/cli.py
+++ b/rony/cli.py
@@ -2,6 +2,7 @@ import click
 import os
 import re
 import sys
+from os import path
 from .writer import copy_files, write_readme_file
 from .__init__ import __version__ as version
 
@@ -48,16 +49,62 @@ def new(project_name):
     copy_files(LOCAL_PATH, project_name)
     write_readme_file(LOCAL_PATH, project_name)
 
-    print(f'Creating virtual environment {project_name}_env')
     os.chdir(project_name)
-    env_name = f"{project_name}_env"
-    os.system(f"python -m venv {env_name}")
+    new.env_name = f"{project_name}_env"
 
     # Create git repo
     os.system('git init')
     print("A git repository was created. You should add your files and make your first commit.\n")
-    
 
+
+env_name = new.env_name    
+    
+def get_operational_system():
+    """
+    Check which user's operating system    
+    """
+    os = sys.platform
+    if sys.platform == "linux":
+        return "Linux"
+    elif sys.platform == "win32":
+        return "Windows"
+    elif sys.platform == "darwin":
+        return "MacOS"
+    elif sys.platform == "freebsd8":
+        return "FreeBSD"
+
+
+def check_version_python():
+    """
+    Checks whether the version of python installed on the system is compatible
+    """
+    if sys.version_info >= (3,6):
+        return True
+    else:
+        return False
+
+def check_python_compile():
+    """
+    Checks python3 path location 
+    """
+    message_env = f"Creating virtual environment {env_name}"
+    if get_operational_system() == "Linux" and check_version_python() == True:
+        if path.exists("/usr/bin/python3") == True:
+            print(message_env)
+            os.system(f"python3 -m venv {env_name}")
+        else:
+            print(message_env)
+            os.system(f"python -m venv {env_name}")
+    elif get_operational_system() == "Windows" and check_version_python() == True:
+        print(message_env)
+        os.system(f"python -m venv {env_name}")
+    elif get_operational_system() == "MacOS" and check_version_python() == True:
+        print(message_env)
+        os.system(f"python -m venv {env_name}")
+    elif check_version_python == False:
+        print('The python version is not supported. Rony is compatible with the version of >= Python 3.6')
+
+check_python_compile()
 
 @click.argument('image_name')
 @cli.command()

--- a/rony/validation.py
+++ b/rony/validation.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from os import path
+
+def get_operational_system():
+    """
+    Check which user's operating system    
+    """
+    os = sys.platform
+    if sys.platform == "linux":
+        return "Linux"
+    elif sys.platform == "win32":
+        return "Windows"
+    elif sys.platform == "darwin":
+        return "MacOS"
+    elif sys.platform == "freebsd8":
+        return "FreeBSD"
+
+
+def check_version_python():
+    """
+    Checks whether the version of python installed on the system is compatible
+    """
+    if sys.version_info >= (3,6):
+        return True
+    else:
+        return False
+
+def check_python_compile():
+    """
+    Checks python3 path location 
+    """
+    env_name = os.environ.get("ENV_NAME")
+    message_env = f"Creating virtual environment {env_name}"
+    if get_operational_system() == "Linux" and check_version_python() == True:
+        if path.exists("/usr/bin/python3") == True:
+            print(message_env)
+            os.system(f"python3 -m venv {env_name}")
+        else:
+            print(message_env)
+            os.system(f"python -m venv {env_name}")
+    elif get_operational_system() == "Windows" and check_version_python() == True:
+        print(message_env)
+        os.system(f"python -m venv {env_name}")
+    elif get_operational_system() == "MacOS" and check_version_python() == True:
+        print(message_env)
+        os.system(f"python -m venv {env_name}")
+    elif check_version_python == False:
+        print('The python version is not supported. Rony is compatible with the version of >= Python 3.6')


### PR DESCRIPTION
Após a tentativa de criação do projeto rony no sistema operacional PopOS com versão do Shell ZSH 5.8, foi detectada uma falha no bloco de código `os.system(f"python -m venv {env_name}")`, o **erro é causado pois o compilador do python não está cetado no caminho `/usr/bin/python` e sim `/usr/bin/python3`**, sendo assim não reconhecido com o comando `python`. Diante do exposto foi desenvolvido funções de validações para tratar esses possíveis erros que são: verificação do sistema operacional, verificação da compatibilidade da versão do python com a framework e verificação do compilador do python para Linux.

![2021-01-14_22-17](https://user-images.githubusercontent.com/64239186/104737095-95e13100-5722-11eb-8b18-a14a68e32a56.png)
