### PR TITLE
Adição de comando diff-2-module e outras alterações menores

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,17 @@ To deal with that a empty file named `.ronyignore` needs to be added to empty fo
 Similarly `.gitignore` files inside the templates would be processed by git and other files could be mistakenly ignored by git. To deal with that the `.gitignore` can be renamed to `.tpl.gitignore`. They will be ignored by git, but will be renamed by Rony when populating the user's project.
 
 
+### Using "diff-2-module" command to create
+
+The diff-2-module command facilitates the creation of new modules.
+
+It translates all the uncommitted changes of a repo into a new module.
+
+To create a new module, just create a project using rony, commit all the files, then make the changes your module should make.
+Run the command `rony diif-2-module <your module name>` inside the project directory, and answer the questions prompted. The new module will be saved to the folder MyRonyModules, in your users home directory.
+
+Always check the module create, as this is a feature under development.
+
 ## Creating plugins for Rony
 
 It is possible to create plugins to extend Rony's functionality. Rony considers a plugin any package which name starts with `rony_`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ To deal with that a empty file named `.ronyignore` needs to be added to empty fo
 Similarly `.gitignore` files inside the templates would be processed by git and other files could be mistakenly ignored by git. To deal with that the `.gitignore` can be renamed to `.tpl.gitignore`. They will be ignored by git, but will be renamed by Rony when populating the user's project.
 
 
-### Using "diff-2-module" command to create
+### Using "diff-2-module" command to create modules
 
 The diff-2-module command facilitates the creation of new modules.
 

--- a/rony/cli.py
+++ b/rony/cli.py
@@ -123,3 +123,15 @@ def add_module(module_name, autoconfirm):
         module_name (str): Name of the module to be added
     """
     write_module(LOCAL_PATH, module_name, autoconfirm)
+
+
+@click.argument("module_name", type = click.STRING, autocompletion=modules_autocomplete)
+@cli.command()
+def diff_2_module(module_name):
+    """Add new module to rony project
+    One should be at the root directory
+
+    Args:
+        module_name (str): Name of the module to be added
+    """
+    create_module_from_diff(module_name)

--- a/rony/cli.py
+++ b/rony/cli.py
@@ -1,8 +1,8 @@
 import click
 import os
 from .validation import get_operational_system, check_version_python, check_python_compile
-from .module_writer import modules_autocomplete, write_module
-from .cli_aux import get_modules_to_add, get_cli_decorators
+from .module_writer import modules_autocomplete, write_module, create_module_from_diff
+from .cli_aux import get_modules_to_add, get_cli_decorators, get_autocomplete
 from .__init__ import __version__ as version
 
 from datetime import datetime
@@ -36,7 +36,7 @@ def info():
 
 @cli.command()
 @click.argument("project_name")
-@click.option('--provider', '-p', default = 'aws')
+@click.option('--provider', '-p', default = 'aws', autocompletion = get_autocomplete('new', 'provider'))
 @click.pass_context
 def new(ctx, project_name, **kwargs):
     """Create a new Rony project

--- a/rony/cli_aux.py
+++ b/rony/cli_aux.py
@@ -39,7 +39,7 @@ def get_modules_to_add(command, opts, ctx):
             all_modules.append('__AWS_BASE__')
 
     for plugin in plugins:
-        if hasattr(plugin, 'cli_aux.get_modules_to_add') and hasattr(plugin.cli_aux, 'get_modules_to_add'):
+        if hasattr(plugin, 'cli_aux') and hasattr(plugin.cli_aux, 'get_modules_to_add'):
             all_modules += plugin.cli_aux.get_modules_to_add(command, opts, ctx)
 
     return all_modules

--- a/rony/cli_aux.py
+++ b/rony/cli_aux.py
@@ -24,7 +24,6 @@ def get_cli_decorators(command):
     return all_decorators
 
 
-
 def get_modules_to_add(command, opts, ctx):
     """Return the modules to be added base on the command ran
 
@@ -40,10 +39,25 @@ def get_modules_to_add(command, opts, ctx):
             all_modules.append('__AWS_BASE__')
 
     for plugin in plugins:
-        if hasattr(plugin, 'cli_aux'):
+        if hasattr(plugin, 'cli_aux.get_modules_to_add') and hasattr(plugin.cli_aux, 'get_modules_to_add'):
             all_modules += plugin.cli_aux.get_modules_to_add(command, opts, ctx)
 
     return all_modules
 
 
+def get_autocomplete(command,opt_name):
 
+    def autocomplete(ctx, args, incomplete):
+        return [opt for opt in options if (incomplete in opt[0])]
+
+    options = []
+
+    if command == 'new':
+        if opt_name == 'provider':
+            options.append(('aws','AWS provider'))
+
+    for plugin in plugins:
+        if hasattr(plugin, 'cli_aux') and hasattr(plugin.cli_aux, 'get_autocomplete'):
+            options += plugin.cli_aux.get_autocomplete(command, opt_name)
+    
+    return autocomplete

--- a/rony/module_writer.py
+++ b/rony/module_writer.py
@@ -35,21 +35,25 @@ def get_modules():
         return v1 < v2
 
     parent_dirs = [rony.__path__[0]] + plugins_dirs
+    modules_dirs = [os.path.join(parent, 'module_templates') for parent in parent_dirs]
+    if os.path.exists(os.path.join(os.path.expanduser('~'), 'MyRonyModules')):
+        modules_dirs += [os.path.join(os.path.expanduser('~'), 'MyRonyModules')]
+
     module_paths = {}
     module_info = {}
     module_desc = {}
 
-    for parent_dir in reversed(parent_dirs):
-        for module_name in next(os.walk(os.path.join(parent_dir, 'module_templates')))[1]:
+    for modules_dir in reversed(modules_dirs):
+        for module_name in next(os.walk(modules_dir))[1]:
 
-            tmp_info = get_module_info(module_name, os.path.join(parent_dir, 'module_templates'))
+            tmp_info = get_module_info(module_name, modules_dir)
             if (
                 (module_name in module_paths.keys()) and 
                 comp_modules_version(tmp_info, module_info[module_name])
             ):
                 continue
             else:
-                module_paths[module_name] = os.path.join(parent_dir, 'module_templates', module_name)
+                module_paths[module_name] = os.path.join(modules_dir, module_name)
                 module_info[module_name] = tmp_info
                 module_desc[module_name] = tmp_info.get('info', '')
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Click',
         'Jinja2',
         'packaging',
+        'unidiff',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Comando diff-2-module, para criar módulos a partir das mudanças não comitadas de um repositório. Novos módulos são salvos na pasta "MyRonyModules", na home do usuário.
[Instruções aqui](https://github.com/RodrigoATorres/rony/blob/feature/new_as_module/CONTRIBUTING.md#using-diff-2-module-command-to-create-modules)

Além dessa funcionalidade, as seguintes mudanças também foram feitas:
- Adicionado autocomplete para opções do comando new (já integradas com os plugin)
- Adicionada pasta "MyRonyModules" no home do usuário às pastas de busca de módulos. Módulos existentes nessa pasta estarão disponíveis no cli do rony